### PR TITLE
OPS-1289 - npm org name change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
     - script: skip
       name: GITHUB
       before_deploy:
-        - echo -e "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGE_TOKEN}\nregistry=https://npm.pkg.github.com/schul-cloud" > .npmrc 2> /dev/null
+        - echo -e "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGE_TOKEN}\nregistry=https://npm.pkg.github.com/hpi-schul-cloud" > .npmrc 2> /dev/null
         - "npm run build"
       deploy:
         provider: script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ## Unreleased
 
 ### Changed
- - OPS-1289 change the name form the npm organisation
+ - OPS-1289 change the npm organisation name
 
 ## 0.2.0 - 2020-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`
 
+## Unreleased
+
+### Changed
+ - OPS-1289 change the name form the npm organisation
+
 ## 0.2.0 - 2020-04-29
 
 ### Added in 0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schul-cloud/styles",
+  "name": "@hpi-schul-cloud/styles",
   "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
   "author": "HPI Schul-Cloud",
-  "name": "@schul-cloud/styles",
+  "name": "@hpi-schul-cloud/styles",
   "version": "0.2.2",
   "license": "AGPL-3.0",
-  "description": "Styles for the @schul-cloud",
-  "homepage": "https://github.com/schul-cloud/styles#readme",
+  "description": "Styles for the @hpi-schul-cloud",
+  "homepage": "https://github.com/hpi-schul-cloud/styles#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/schul-cloud/styles.git"
+    "url": "git+https://github.com/hpi-schul-cloud/styles.git"
   },
   "bugs": {
-    "url": "https://github.com/schul-cloud/styles/issues"
+    "url": "https://github.com/hpi-schul-cloud/styles/issues"
   },
   "keywords": [
     "styles",
     "design-tokens",
-    "schul-cloud",
+    "hpi-schul-cloud",
     "design-system",
     "scss",
     "css"


### PR DESCRIPTION
# Description
 - This pullrequest change the NPM Organisation name to hpi-schul-cloud
## Links to Tickets or other pull requests
 - https://ticketsystem.hpi-schul-cloud.org/browse/OPS-1289
## Changes
 - Name of the NPM Organisation

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
 - only name change to hpi-schul-cloud

## Deployment
 - with the next styl release
## New Repos, NPM pakages or vendor scripts
 - new NPM Organisation name
## Screenshots of UI changes
 - No UI changes

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
