### PR TITLE
OPS-1289 - npm org name change, again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Changed
 
-- OPS-1289 - change the npm organisation name
+- OPS-1289 - change the npm organisation name, second time after someone undo it
 
 ## 0.2.0 - 2020-04-29
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # styles
-The node package for default Schul-Cloud styles
+The node package for default HPI-Schul-Cloud styles
 
 ## What does it provide?
 
 It provides 
 
-- build/css/default/variables.css: A full list of CSS variables for the Schul-Cloud default theme
+- build/css/default/variables.css: A full list of CSS variables for the HPI-Schul-Cloud default theme
 
 ## How to use it?
 
-Import it in your Schul-Cloud project 
+Import it in your HPI-Schul-Cloud project 
 
-``@import "~@schul-cloud/styles/build/css/default/variables.css";``
+``@import "~@hpi-schul-cloud/styles/build/css/default/variables.css";``
 
 ## What's next?
 
 - [ ] other formats (e.g. SCSS) - provide scss variables to import
-- [ ] other themes - provide variables ready to use for other themes like open, thr, n21, ... ([example theme variables](https://github.com/schul-cloud/nuxt-client/blob/develop/src/themes/open/styles/variables/_colors.scss))
+- [ ] other themes - provide variables ready to use for other themes like open, thr, n21, ... ([example theme variables](https://github.com/hpi-schul-cloud/nuxt-client/blob/develop/src/themes/open/styles/variables/_colors.scss))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schul-cloud/styles",
+  "name": "@hpi-schul-cloud/styles",
   "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpi-schul-cloud/styles",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "author": "HPI Schul-Cloud",
-  "name": "@schul-cloud/styles",
+  "name": "@hpi-schul-cloud/styles",
   "version": "0.2.3",
   "license": "AGPL-3.0",
   "description": "Styles for the @hpi-schul-cloud",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "HPI Schul-Cloud",
   "name": "@hpi-schul-cloud/styles",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "AGPL-3.0",
   "description": "Styles for the @hpi-schul-cloud",
   "homepage": "https://github.com/hpi-schul-cloud/styles#readme",


### PR DESCRIPTION
# Description
 - This pullrequest change the NPM Organisation name to hpi-schul-cloud
## Links to Tickets or other pull requests
 - https://ticketsystem.hpi-schul-cloud.org/browse/OPS-1289
## Changes
 - Name of the NPM Organisation

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
 - only name change to hpi-schul-cloud

## Deployment
 - with the next styl release
## New Repos, NPM pakages or vendor scripts
 - new NPM Organisation name
## Screenshots of UI changes
 - No UI changes

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
